### PR TITLE
fix: TransferToOperatorBlock; приоритет .handle

### DIFF
--- a/src/components/builder/blocks/transfer-to-operator/transfer-to-operator.tsx
+++ b/src/components/builder/blocks/transfer-to-operator/transfer-to-operator.tsx
@@ -8,15 +8,13 @@ import {
 const TransferToOperatorBlock: FC<TBlockProps<TOperatorBlock>> = ({ data }) => {
   const [name, setName] = useState(data.name);
 
-  const handleNameChange = (newName: string) => {
-    setName(newName);
-  };
-
   return (
     <ControlLayout
       type="Перевод на оператора"
       name={name}
-      nameSetter={handleNameChange}
+      nameSetter={(newName: string) => {
+        setName(newName);
+      }}
     />
   );
 };

--- a/src/components/builder/flow/custom-handle/custom-handle.module.scss
+++ b/src/components/builder/flow/custom-handle/custom-handle.module.scss
@@ -1,7 +1,7 @@
 @use '../../../../stylesheets/variables' as *;
 @use '../../../../stylesheets/mixins' as *;
 
-.handle {
+.handle.handle {
   @include size(10px, 10px);
   display: block;
   border: $border-radius-circle;


### PR DESCRIPTION
1. Упрощен код TransferToOperatorBlock
2. Увеличен вес селектора .handle в CustomHandle для проявления кастомных стилей ручек нод.