### PR TITLE
Draft:  логика добавления бота

### DIFF
--- a/src/api/bots.ts
+++ b/src/api/bots.ts
@@ -6,6 +6,7 @@ import {
   IGetTemplatesBotsResponse,
   TCreateBot,
 } from '../services/types/bot';
+import { getAccessToken } from '../auth/authService';
 
 // запрос получения ботов
 function getBotsApi(token: string) {
@@ -19,12 +20,9 @@ function getBotsApi(token: string) {
 }
 
 // запрос добавления бота
-function addBotApi(
-  bot: TCreateBot,
-  token: string | null,
-  templateId: string | null
-) {
+function addBotApi(bot: TCreateBot, templateId: string | null) {
   const url = `bots/${templateId || ''}`;
+  const token = getAccessToken();
   return request<IAddBotResponse>(url, {
     method: 'POST',
     headers: {

--- a/src/api/bots.ts
+++ b/src/api/bots.ts
@@ -9,7 +9,8 @@ import {
 import { getAccessToken } from '../auth/authService';
 
 // запрос получения ботов
-function getBotsApi(token: string) {
+function getBotsApi() {
+  const token = getAccessToken();
   return request<IGetBotsResponse>('bots', {
     method: 'GET',
     headers: {

--- a/src/api/bots.ts
+++ b/src/api/bots.ts
@@ -4,7 +4,7 @@ import {
   IAddBotResponse,
   IGetBotsResponse,
   IGetTemplatesBotsResponse,
-  TBot,
+  TCreateBot,
 } from '../services/types/bot';
 
 // запрос получения ботов
@@ -19,8 +19,13 @@ function getBotsApi(token: string) {
 }
 
 // запрос добавления бота
-function addBotApi(bot: TBot, token: string) {
-  return request<IAddBotResponse>('bots', {
+function addBotApi(
+  bot: TCreateBot,
+  token: string | null,
+  templateId: string | null
+) {
+  const url = `bots/${templateId || ''}`;
+  return request<IAddBotResponse>(url, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json;charset=utf-8',

--- a/src/api/bots.ts
+++ b/src/api/bots.ts
@@ -2,6 +2,7 @@ import request from './api';
 
 import {
   IAddBotResponse,
+  IDeleteBotResponse,
   IGetBotsResponse,
   IGetTemplatesBotsResponse,
   TCreateBot,
@@ -34,6 +35,18 @@ function addBotApi(bot: TCreateBot, templateId: string | null) {
   });
 }
 
+function deleteBotApi(id: string) {
+  const url = `bots/${id || ''}`;
+  const token = getAccessToken();
+  return request<IDeleteBotResponse>(url, {
+    method: 'DELETE',
+    headers: {
+      'Content-Type': 'application/json;charset=utf-8',
+      authorization: `Bearer ${token}`,
+    },
+  });
+}
+
 // запрос получения шаблонов
 function getTemplatesBotsApi(token: string) {
   return request<IGetTemplatesBotsResponse>('bots/templates', {
@@ -45,4 +58,4 @@ function getTemplatesBotsApi(token: string) {
   });
 }
 
-export { getBotsApi, addBotApi, getTemplatesBotsApi };
+export { getBotsApi, addBotApi, deleteBotApi, getTemplatesBotsApi };

--- a/src/components/add-bot/create-bot/create-bot.stories.tsx
+++ b/src/components/add-bot/create-bot/create-bot.stories.tsx
@@ -46,6 +46,7 @@ export const CreateBotFacebook: Story = {
     pages: true,
     botURI: false,
     templateId: null,
+    templateTitle: null,
   },
 };
 
@@ -55,6 +56,7 @@ export const CreateBotTelegram: Story = {
     pages: false,
     botURI: false,
     templateId: null,
+    templateTitle: null,
   },
 };
 
@@ -64,5 +66,6 @@ export const CreateBotViber: Story = {
     pages: false,
     botURI: true,
     templateId: null,
+    templateTitle: null,
   },
 };

--- a/src/components/add-bot/create-bot/create-bot.stories.tsx
+++ b/src/components/add-bot/create-bot/create-bot.stories.tsx
@@ -45,6 +45,7 @@ export const CreateBotFacebook: Story = {
     botName: 'Facebook',
     pages: true,
     botURI: false,
+    templateId: null,
   },
 };
 
@@ -53,6 +54,7 @@ export const CreateBotTelegram: Story = {
     botName: 'Telegram',
     pages: false,
     botURI: false,
+    templateId: null,
   },
 };
 
@@ -61,5 +63,6 @@ export const CreateBotViber: Story = {
     botName: 'Viber',
     pages: false,
     botURI: true,
+    templateId: null,
   },
 };

--- a/src/components/add-bot/create-bot/create-bot.tsx
+++ b/src/components/add-bot/create-bot/create-bot.tsx
@@ -65,7 +65,7 @@ const CreateBot: FC<ICreateBot> = ({
     uri: { value: '', valueValid: false },
   });
 
-  const history = useNavigate();
+  const navigate = useNavigate();
 
   const disabledDefault =
     values.accessKey.value.length > 1 && values.botName.value.length > 1;
@@ -87,7 +87,7 @@ const CreateBot: FC<ICreateBot> = ({
     try {
       const addedBot = await addBotApi(bot, template);
       // eslint-disable-next-line no-underscore-dangle
-      history(`/${routesUrl.botBuilder}?id=${addedBot._id}&type=custom`);
+      navigate(`/${routesUrl.botBuilder}?id=${addedBot._id}&type=custom`);
     } catch (err) {
       // eslint-disable-next-line no-console
       console.log(err);

--- a/src/components/add-bot/create-bot/create-bot.tsx
+++ b/src/components/add-bot/create-bot/create-bot.tsx
@@ -21,15 +21,13 @@ import Button from '../../../ui/buttons/button/button';
 import Input from '../../../ui/inputs/input/input';
 
 import routesUrl from '../../../utils/routesData';
-import { getAccessToken } from '../../../auth/authService';
 import Typography from '../../../ui/typography/typography';
 import { addBotApi } from '../../../api';
-import { TCreateBot } from '../../../services/types/bot';
+import type { TCreateBot } from '../../../services/types/bot';
 
 interface ImageMap {
   [key: string]: JSX.Element;
 }
-
 interface ICreateBot {
   botName: string;
   pages: boolean;
@@ -58,7 +56,7 @@ const CreateBot: FC<ICreateBot> = ({
   templateId,
   templateTitle,
   botURI,
-}): JSX.Element => {
+}) => {
   const [arrPages, setArrPages] = useState<string[]>([]);
 
   const { values, handleChange, setValues } = useForm({
@@ -68,8 +66,6 @@ const CreateBot: FC<ICreateBot> = ({
   });
 
   const history = useNavigate();
-
-  const token = getAccessToken();
 
   const disabledDefault =
     values.accessKey.value.length > 1 && values.botName.value.length > 1;
@@ -87,6 +83,17 @@ const CreateBot: FC<ICreateBot> = ({
     ? !disabledDefault
     : !disabledPages;
 
+  const addBot = async (bot: TCreateBot, template: string | null) => {
+    try {
+      const addedBot = await addBotApi(bot, template);
+      // eslint-disable-next-line no-underscore-dangle
+      history(`/${routesUrl.botBuilder}?id=${addedBot._id}&type=custom`);
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.log(err);
+    }
+  };
+
   const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
@@ -102,15 +109,7 @@ const CreateBot: FC<ICreateBot> = ({
       ],
     };
 
-    try {
-      const bot = await addBotApi(dataBot, token, templateId);
-      // eslint-disable-next-line no-underscore-dangle
-      const botId = bot._id;
-      history(`/${routesUrl.botBuilder}?id=${botId}&type=custom`);
-    } catch (err) {
-      // eslint-disable-next-line no-console
-      console.log(err);
-    }
+    addBot(dataBot, templateId);
 
     setValues({
       botName: { value: '', valueValid: false },

--- a/src/components/add-bot/create-bot/create-bot.tsx
+++ b/src/components/add-bot/create-bot/create-bot.tsx
@@ -5,7 +5,7 @@ import { useNavigate } from 'react-router';
 import stylesCreateBot from './create-bot.module.scss';
 import { addBotAction } from '../../../services/actions/bots/addBot';
 
-import { useAppDispatch, useAppSelector } from '../../../services/hooks/hooks';
+import { useAppDispatch } from '../../../services/hooks/hooks';
 
 import { ReactComponent as Odnoklassniki } from '../../../images/icon/40x40/odnoklassniki/hover.svg';
 import { ReactComponent as Telegram } from '../../../images/icon/40x40/telegram/hover.svg';
@@ -26,7 +26,6 @@ import Input from '../../../ui/inputs/input/input';
 import routesUrl from '../../../utils/routesData';
 import { getAccessToken } from '../../../auth/authService';
 import Typography from '../../../ui/typography/typography';
-import { getTemplatesBotsSel } from '../../../utils/selectorData';
 
 interface ImageMap {
   [key: string]: JSX.Element;
@@ -35,7 +34,8 @@ interface ImageMap {
 interface ICreateBot {
   botName: string;
   pages: boolean;
-  templateId: string | null;
+  templateId?: string | null;
+  templateTitle: string | null;
   botURI?: boolean;
 }
 
@@ -56,17 +56,12 @@ const img: ImageMap = {
 const CreateBot: FC<ICreateBot> = ({
   botName,
   pages,
+  // TODO: использовать при запросе на сервер
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   templateId,
+  templateTitle,
   botURI,
 }): JSX.Element => {
-  const { templatesBots } = useAppSelector(getTemplatesBotsSel);
-  console.log(templateId);
-  const templateName = templatesBots.find(
-    // eslint-disable-next-line no-underscore-dangle
-    (template) => template._id === templateId
-  )?.title;
-  console.log(templateName);
-
   const [arrPages, setArrPages] = useState<string[]>([]);
 
   const { values, handleChange, setValues } = useForm({
@@ -141,18 +136,15 @@ const CreateBot: FC<ICreateBot> = ({
             >
               {botName}
             </Typography>
-            {templateName && (
+            {templateTitle && (
               <Typography
                 tag="span"
                 className={stylesCreateBot.create_main_bot_name_text}
               >
-                Бот будет создан на основе{' '}
-                <Typography
-                  tag="span"
-                  className={stylesCreateBot.create_main_bot_name_span}
-                >
-                  {templateName}
-                </Typography>
+                Бот будет создан на основе шаблона{' '}
+                <span className={stylesCreateBot.create_main_bot_name_span}>
+                  {templateTitle}
+                </span>
               </Typography>
             )}
           </div>

--- a/src/components/add-bot/create-bot/create-bot.tsx
+++ b/src/components/add-bot/create-bot/create-bot.tsx
@@ -5,7 +5,7 @@ import { useNavigate } from 'react-router';
 import stylesCreateBot from './create-bot.module.scss';
 import { addBotAction } from '../../../services/actions/bots/addBot';
 
-import { useAppDispatch } from '../../../services/hooks/hooks';
+import { useAppDispatch, useAppSelector } from '../../../services/hooks/hooks';
 
 import { ReactComponent as Odnoklassniki } from '../../../images/icon/40x40/odnoklassniki/hover.svg';
 import { ReactComponent as Telegram } from '../../../images/icon/40x40/telegram/hover.svg';
@@ -26,6 +26,7 @@ import Input from '../../../ui/inputs/input/input';
 import routesUrl from '../../../utils/routesData';
 import { getAccessToken } from '../../../auth/authService';
 import Typography from '../../../ui/typography/typography';
+import { getTemplatesBotsSel } from '../../../utils/selectorData';
 
 interface ImageMap {
   [key: string]: JSX.Element;
@@ -34,6 +35,7 @@ interface ImageMap {
 interface ICreateBot {
   botName: string;
   pages: boolean;
+  templateId: string | null;
   botURI?: boolean;
 }
 
@@ -51,7 +53,20 @@ const img: ImageMap = {
   'Веб-сайт': <WebSite className={stylesCreateBot.create_main_bot_name_img} />,
 };
 
-const CreateBot: FC<ICreateBot> = ({ botName, pages, botURI }): JSX.Element => {
+const CreateBot: FC<ICreateBot> = ({
+  botName,
+  pages,
+  templateId,
+  botURI,
+}): JSX.Element => {
+  const { templatesBots } = useAppSelector(getTemplatesBotsSel);
+  console.log(templateId);
+  const templateName = templatesBots.find(
+    // eslint-disable-next-line no-underscore-dangle
+    (template) => template._id === templateId
+  )?.title;
+  console.log(templateName);
+
   const [arrPages, setArrPages] = useState<string[]>([]);
 
   const { values, handleChange, setValues } = useForm({
@@ -126,18 +141,20 @@ const CreateBot: FC<ICreateBot> = ({ botName, pages, botURI }): JSX.Element => {
             >
               {botName}
             </Typography>
-            <Typography
-              tag="span"
-              className={stylesCreateBot.create_main_bot_name_text}
-            >
-              Бот будет создан на основе{' '}
+            {templateName && (
               <Typography
                 tag="span"
-                className={stylesCreateBot.create_main_bot_name_span}
+                className={stylesCreateBot.create_main_bot_name_text}
               >
-                BotName
+                Бот будет создан на основе{' '}
+                <Typography
+                  tag="span"
+                  className={stylesCreateBot.create_main_bot_name_span}
+                >
+                  {templateName}
+                </Typography>
               </Typography>
-            </Typography>
+            )}
           </div>
           <form
             onSubmit={handleSubmit}

--- a/src/components/bot-card/bot-card.module.scss
+++ b/src/components/bot-card/bot-card.module.scss
@@ -13,6 +13,11 @@
   }
 }
 
+.wrapper {
+  &:hover {
+    cursor: $cursor;
+  }
+}
 .icon {
   @include size(52px, 52px);
   margin: 24px 0 0 32px;

--- a/src/components/bot-card/bot-card.tsx
+++ b/src/components/bot-card/bot-card.tsx
@@ -1,43 +1,39 @@
 import { FC, useState } from 'react';
 
-import stylesBotCard from './bot-card.module.scss';
+import styles from './bot-card.module.scss';
 
 import tg from '../../images/icon/40x40/telegram/default.svg';
 
 import MoreMybotPopup from '../popups/more-mybot/more-mybot';
 import Typography from '../../ui/typography/typography';
+import { TBot } from '../../services/types/bot';
 
 export interface IBotCard {
+  bot: TBot;
   platform_icon: string;
-  bot_name: string;
-  bot_id?: string;
+  // onClick: (id: string) => void;
 }
 
-const BotCard: FC<IBotCard> = ({
-  platform_icon = tg,
-  bot_name = 'Название бота',
-  bot_id = '980809809',
-}): JSX.Element => {
+const BotCard: FC<IBotCard> = ({ platform_icon = tg, bot }): JSX.Element => {
   const [isActive, setIsActive] = useState(false);
 
   return (
-    <div className={stylesBotCard.card}>
-      <img className={stylesBotCard.icon} src={platform_icon} alt="иконка" />
+    <div className={styles.card}>
+      <img className={styles.icon} src={platform_icon} alt="иконка" />
       <div
-        className={stylesBotCard.more_button}
+        className={styles.more_button}
         onClick={() => setIsActive(!isActive)}
         aria-label="Меню настроек бота"
       />
-      <div className={stylesBotCard.name_box}>
-        <Typography
-          tag="p"
-          fontFamily="secondary"
-          className={stylesBotCard.name}
-        >
-          {bot_name}
+      <div className={styles.name_box}>
+        <Typography tag="p" fontFamily="secondary" className={styles.name}>
+          {bot.title}
         </Typography>
       </div>
-      {isActive && <MoreMybotPopup setIsOpen={setIsActive} idMyBot={bot_id} />}
+      {
+        // eslint-disable-next-line no-underscore-dangle
+        isActive && <MoreMybotPopup setIsOpen={setIsActive} idMyBot={bot._id} />
+      }
     </div>
   );
 };

--- a/src/components/bot-card/bot-card.tsx
+++ b/src/components/bot-card/bot-card.tsx
@@ -1,5 +1,6 @@
 import { FC, useState } from 'react';
 
+import { useNavigate } from 'react-router';
 import styles from './bot-card.module.scss';
 
 import tg from '../../images/icon/40x40/telegram/default.svg';
@@ -7,6 +8,7 @@ import tg from '../../images/icon/40x40/telegram/default.svg';
 import MoreMybotPopup from '../popups/more-mybot/more-mybot';
 import Typography from '../../ui/typography/typography';
 import { TBot } from '../../services/types/bot';
+import routesUrl from '../../utils/routesData';
 
 export interface IBotCard {
   bot: TBot;
@@ -16,19 +18,28 @@ export interface IBotCard {
 
 const BotCard: FC<IBotCard> = ({ platform_icon = tg, bot }): JSX.Element => {
   const [isActive, setIsActive] = useState(false);
+  const navigate = useNavigate();
 
   return (
     <div className={styles.card}>
-      <img className={styles.icon} src={platform_icon} alt="иконка" />
       <div
         className={styles.more_button}
         onClick={() => setIsActive(!isActive)}
         aria-label="Меню настроек бота"
       />
-      <div className={styles.name_box}>
-        <Typography tag="p" fontFamily="secondary" className={styles.name}>
-          {bot.title}
-        </Typography>
+      <div
+        className={styles.wrapper}
+        onClick={() => {
+          // eslint-disable-next-line no-underscore-dangle
+          navigate(`/${routesUrl.botBuilder}?id=${bot._id}`);
+        }}
+      >
+        <img className={styles.icon} src={platform_icon} alt="иконка" />
+        <div className={styles.name_box}>
+          <Typography tag="p" fontFamily="secondary" className={styles.name}>
+            {bot.title}
+          </Typography>
+        </div>
       </div>
       {
         // eslint-disable-next-line no-underscore-dangle

--- a/src/components/dashbord/bots-templates/bots-templates.module.scss
+++ b/src/components/dashbord/bots-templates/bots-templates.module.scss
@@ -68,12 +68,6 @@
   }
 }
 
-.item {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(134px, 188px));
-  align-items: flex-start;
-}
-
 .accordion_wrapper {
   @include flex(row);
 }
@@ -109,25 +103,4 @@
   @media (max-width: $switching-width) {
     display: none;
   }
-}
-
-.modal_overlay {
-  @include size(100%, 100%);
-  @include position(fixed, 0, $left: 0);
-  display: flex;
-  z-index: 2;
-  cursor: $cursor;
-  background-color: rgba(0, 0, 0, 0.1);
-}
-
-.modal {
-  @include flex(row, center, center);
-  @include size(100%, 100%);
-  @include position(fixed, 0, $left: 0);
-  z-index: 100;
-}
-
-.content {
-  position: absolute;
-  z-index: 2;
 }

--- a/src/components/dashbord/bots-templates/bots-templates.tsx
+++ b/src/components/dashbord/bots-templates/bots-templates.tsx
@@ -2,51 +2,12 @@ import { FC, useEffect, useRef, useState } from 'react';
 import { useDraggable } from 'react-use-draggable-scroll';
 import styles from './bots-templates.module.scss';
 
-import ButtonAddSampleBot from '../../../ui/buttons/button-add-sample-bot/button-add-sample-bot';
-import BotTemplatePopup from '../../popups/bot-template-popup/bot-template-popup';
-import ModalPopup from '../../popups/modal-popup/modal-popup';
-import useModal from '../../../services/hooks/use-modal';
 import { useAppDispatch, useAppSelector } from '../../../services/hooks/hooks';
 import { getTemplatesBotsAction } from '../../../services/actions/bots/getTemplatesBots';
 import { getAccessToken } from '../../../auth/authService';
 import { getTemplatesBotsSel } from '../../../utils/selectorData';
 import Typography from '../../../ui/typography/typography';
-import { TTemplateBot } from '../../../services/types/bot';
-
-const Template: FC<{ template: TTemplateBot }> = ({ template }) => {
-  const importImage = async () => {
-    try {
-      const imageModule = await import(
-        `../../../images/icon/template/${template.icon}.svg`
-      );
-      return imageModule.default;
-    } catch (error) {
-      return 'null';
-    }
-  };
-
-  const [image, setImage] = useState<string>('');
-  const { isModalOpen, closeModal, openModal } = useModal();
-
-  useEffect(() => {
-    importImage().then((importedImage) => {
-      setImage(importedImage);
-    });
-  }, [template.icon]);
-
-  return (
-    <li className={styles.item}>
-      <ButtonAddSampleBot onClick={openModal} icon={image}>
-        {template.title}
-      </ButtonAddSampleBot>
-      {isModalOpen && (
-        <ModalPopup onClick={closeModal}>
-          <BotTemplatePopup template={template} onClick={closeModal} />
-        </ModalPopup>
-      )}
-    </li>
-  );
-};
+import Template from '../template/template';
 
 const Templates: FC = () => {
   const { templatesBots } = useAppSelector(getTemplatesBotsSel);

--- a/src/components/dashbord/bots-templates/bots-templates.tsx
+++ b/src/components/dashbord/bots-templates/bots-templates.tsx
@@ -1,6 +1,6 @@
 import { FC, useEffect, useRef, useState } from 'react';
 import { useDraggable } from 'react-use-draggable-scroll';
-import stylesTemplates from './bots-templates.module.scss';
+import styles from './bots-templates.module.scss';
 
 import ButtonAddSampleBot from '../../../ui/buttons/button-add-sample-bot/button-add-sample-bot';
 import BotTemplatePopup from '../../popups/bot-template-popup/bot-template-popup';
@@ -11,17 +11,13 @@ import { getTemplatesBotsAction } from '../../../services/actions/bots/getTempla
 import { getAccessToken } from '../../../auth/authService';
 import { getTemplatesBotsSel } from '../../../utils/selectorData';
 import Typography from '../../../ui/typography/typography';
+import { TTemplateBot } from '../../../services/types/bot';
 
-const Template: FC<{
-  title: string;
-  description: string;
-  fileName: string;
-  id: string;
-}> = ({ title, description, fileName, id }): JSX.Element => {
+const Template: FC<{ template: TTemplateBot }> = ({ template }) => {
   const importImage = async () => {
     try {
       const imageModule = await import(
-        `../../../images/icon/template/${fileName}.svg`
+        `../../../images/icon/template/${template.icon}.svg`
       );
       return imageModule.default;
     } catch (error) {
@@ -36,28 +32,23 @@ const Template: FC<{
     importImage().then((importedImage) => {
       setImage(importedImage);
     });
-  }, [fileName]);
+  }, [template.icon]);
 
   return (
-    <li className={stylesTemplates.item}>
+    <li className={styles.item}>
       <ButtonAddSampleBot onClick={openModal} icon={image}>
-        {title}
+        {template.title}
       </ButtonAddSampleBot>
       {isModalOpen && (
         <ModalPopup onClick={closeModal}>
-          <BotTemplatePopup
-            title={title}
-            description={description}
-            id={id}
-            onClick={closeModal}
-          />
+          <BotTemplatePopup template={template} onClick={closeModal} />
         </ModalPopup>
       )}
     </li>
   );
 };
 
-const Templates: FC = (): JSX.Element => {
+const Templates: FC = () => {
   const { templatesBots } = useAppSelector(getTemplatesBotsSel);
 
   const dispatch = useAppDispatch();
@@ -75,14 +66,14 @@ const Templates: FC = (): JSX.Element => {
   const { events } = useDraggable(ref);
 
   return (
-    <div className={stylesTemplates.container}>
-      <div className={stylesTemplates.header_wrapper}>
+    <div className={styles.container}>
+      <div className={styles.header_wrapper}>
         <Typography tag="h2" fontFamily="secondary">
           Шаблоны
         </Typography>
-        <div className={stylesTemplates.accordion_wrapper}>
+        <div className={styles.accordion_wrapper}>
           <button
-            className={stylesTemplates.accordion_button}
+            className={styles.accordion_button}
             type="button"
             onClick={() => {
               setIsExpanded(!isExpanded);
@@ -93,8 +84,8 @@ const Templates: FC = (): JSX.Element => {
           </button>
 
           <button
-            className={`${stylesTemplates.accordion_ico_plus} ${
-              isExpanded ? stylesTemplates.accordion_ico_minus : ''
+            className={`${styles.accordion_ico_plus} ${
+              isExpanded ? styles.accordion_ico_minus : ''
             }`}
             type="button"
             onClick={() => {
@@ -106,21 +97,17 @@ const Templates: FC = (): JSX.Element => {
       </div>
       <ul
         className={`
-          ${stylesTemplates.list} ${
-            isExpanded ? stylesTemplates.expanded : stylesTemplates.not_expanded
+          ${styles.list} ${
+            isExpanded ? styles.expanded : styles.not_expanded
           } `}
         {...events}
         ref={ref}
       >
-        {templatesBots.map((templateBot) => (
+        {templatesBots.map((template) => (
           <Template
             // eslint-disable-next-line no-underscore-dangle
-            key={templateBot._id}
-            title={templateBot.title}
-            description={templateBot.description}
-            fileName={templateBot.icon}
-            // eslint-disable-next-line no-underscore-dangle
-            id={templateBot._id}
+            key={template._id}
+            template={template}
           />
         ))}
       </ul>

--- a/src/components/dashbord/bots-templates/bots-templates.tsx
+++ b/src/components/dashbord/bots-templates/bots-templates.tsx
@@ -3,7 +3,7 @@ import { useDraggable } from 'react-use-draggable-scroll';
 import stylesTemplates from './bots-templates.module.scss';
 
 import ButtonAddSampleBot from '../../../ui/buttons/button-add-sample-bot/button-add-sample-bot';
-import BotTemplate from '../../popups/bot-template-popup/bot-template-popup';
+import BotTemplatePopup from '../../popups/bot-template-popup/bot-template-popup';
 import ModalPopup from '../../popups/modal-popup/modal-popup';
 import useModal from '../../../services/hooks/use-modal';
 import { useAppDispatch, useAppSelector } from '../../../services/hooks/hooks';
@@ -12,11 +12,12 @@ import { getAccessToken } from '../../../auth/authService';
 import { getTemplatesBotsSel } from '../../../utils/selectorData';
 import Typography from '../../../ui/typography/typography';
 
-const Template: FC<{ name: string; description: string; fileName: string }> = ({
-  name,
-  description,
-  fileName,
-}): JSX.Element => {
+const Template: FC<{
+  name: string;
+  description: string;
+  fileName: string;
+  id: string;
+}> = ({ name, description, fileName, id }): JSX.Element => {
   const importImage = async () => {
     try {
       const imageModule = await import(
@@ -44,9 +45,10 @@ const Template: FC<{ name: string; description: string; fileName: string }> = ({
       </ButtonAddSampleBot>
       {isModalOpen && (
         <ModalPopup onClick={closeModal}>
-          <BotTemplate
+          <BotTemplatePopup
             title={name}
             description={description}
+            id={id}
             onClick={closeModal}
           />
         </ModalPopup>
@@ -110,12 +112,15 @@ const Templates: FC = (): JSX.Element => {
         {...events}
         ref={ref}
       >
-        {templatesBots.map((templateBot, index) => (
+        {templatesBots.map((templateBot) => (
           <Template
-            key={templateBot.title + +index}
+            // eslint-disable-next-line no-underscore-dangle
+            key={templateBot._id}
             name={templateBot.title}
             description={templateBot.description}
             fileName={templateBot.icon}
+            // eslint-disable-next-line no-underscore-dangle
+            id={templateBot._id}
           />
         ))}
       </ul>

--- a/src/components/dashbord/bots-templates/bots-templates.tsx
+++ b/src/components/dashbord/bots-templates/bots-templates.tsx
@@ -13,11 +13,11 @@ import { getTemplatesBotsSel } from '../../../utils/selectorData';
 import Typography from '../../../ui/typography/typography';
 
 const Template: FC<{
-  name: string;
+  title: string;
   description: string;
   fileName: string;
   id: string;
-}> = ({ name, description, fileName, id }): JSX.Element => {
+}> = ({ title, description, fileName, id }): JSX.Element => {
   const importImage = async () => {
     try {
       const imageModule = await import(
@@ -41,12 +41,12 @@ const Template: FC<{
   return (
     <li className={stylesTemplates.item}>
       <ButtonAddSampleBot onClick={openModal} icon={image}>
-        {name}
+        {title}
       </ButtonAddSampleBot>
       {isModalOpen && (
         <ModalPopup onClick={closeModal}>
           <BotTemplatePopup
-            title={name}
+            title={title}
             description={description}
             id={id}
             onClick={closeModal}
@@ -116,7 +116,7 @@ const Templates: FC = (): JSX.Element => {
           <Template
             // eslint-disable-next-line no-underscore-dangle
             key={templateBot._id}
-            name={templateBot.title}
+            title={templateBot.title}
             description={templateBot.description}
             fileName={templateBot.icon}
             // eslint-disable-next-line no-underscore-dangle

--- a/src/components/dashbord/my-bots/my-bots.tsx
+++ b/src/components/dashbord/my-bots/my-bots.tsx
@@ -88,12 +88,7 @@ const MyBots: FC = (): JSX.Element => {
       <ul className={`${styles.list}  ${isHidden ? styles.list_hidden : ''}`}>
         {bots.map((bot, index) => (
           <li key={bot.title + +index} className={styles.item}>
-            <BotCard
-              platform_icon={img[bot.messengers[0].name]}
-              bot_name={bot.title}
-              // eslint-disable-next-line no-underscore-dangle
-              bot_id={bot._id}
-            />
+            <BotCard platform_icon={img[bot.messengers[0].name]} bot={bot} />
           </li>
         ))}
         <li className={styles.buttonAddbot}>

--- a/src/components/dashbord/my-bots/my-bots.tsx
+++ b/src/components/dashbord/my-bots/my-bots.tsx
@@ -86,14 +86,14 @@ const MyBots: FC = (): JSX.Element => {
         )}
       </div>
       <ul className={`${styles.list}  ${isHidden ? styles.list_hidden : ''}`}>
+        <li className={styles.buttonAddbot}>
+          <ButtonAddBot onClick={addBot}>Добавить бота</ButtonAddBot>
+        </li>
         {bots.map((bot, index) => (
           <li key={bot.title + +index} className={styles.item}>
             <BotCard platform_icon={img[bot.messengers[0].name]} bot={bot} />
           </li>
         ))}
-        <li className={styles.buttonAddbot}>
-          <ButtonAddBot onClick={addBot}>Добавить бота</ButtonAddBot>
-        </li>
       </ul>
     </div>
   );

--- a/src/components/dashbord/template/template.module.scss
+++ b/src/components/dashbord/template/template.module.scss
@@ -1,0 +1,5 @@
+.item {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(134px, 188px));
+  align-items: flex-start;
+}

--- a/src/components/dashbord/template/template.tsx
+++ b/src/components/dashbord/template/template.tsx
@@ -1,0 +1,45 @@
+import { FC, useEffect, useState } from 'react';
+import styles from './template.module.scss';
+
+import ButtonAddSampleBot from '../../../ui/buttons/button-add-sample-bot/button-add-sample-bot';
+import BotTemplatePopup from '../../popups/bot-template-popup/bot-template-popup';
+import ModalPopup from '../../popups/modal-popup/modal-popup';
+import useModal from '../../../services/hooks/use-modal';
+import { TTemplateBot } from '../../../services/types/bot';
+
+const Template: FC<{ template: TTemplateBot }> = ({ template }) => {
+  const importImage = async () => {
+    try {
+      const imageModule = await import(
+        `../../../images/icon/template/${template.icon}.svg`
+      );
+      return imageModule.default;
+    } catch (error) {
+      return 'null';
+    }
+  };
+
+  const [image, setImage] = useState<string>('');
+  const { isModalOpen, closeModal, openModal } = useModal();
+
+  useEffect(() => {
+    importImage().then((importedImage) => {
+      setImage(importedImage);
+    });
+  }, [template.icon]);
+
+  return (
+    <li className={styles.item}>
+      <ButtonAddSampleBot onClick={openModal} icon={image}>
+        {template.title}
+      </ButtonAddSampleBot>
+      {isModalOpen && (
+        <ModalPopup onClick={closeModal}>
+          <BotTemplatePopup template={template} onClick={closeModal} />
+        </ModalPopup>
+      )}
+    </li>
+  );
+};
+
+export default Template;

--- a/src/components/popups/bot-template-popup/bot-template-popup.tsx
+++ b/src/components/popups/bot-template-popup/bot-template-popup.tsx
@@ -1,7 +1,7 @@
 import { FC } from 'react';
 import { useNavigate } from 'react-router';
 
-import stylesBotTemplate from './bot-template-popup.module.scss';
+import styles from './bot-template-popup.module.scss';
 
 import { ReactComponent as ImageAnswer } from '../../../images/icon/template/answering machine.svg';
 import { ReactComponent as ImageEntertain } from '../../../images/icon/template/entertainment.svg';
@@ -19,11 +19,10 @@ import { ReactComponent as ImagePoll } from '../../../images/icon/template/poll.
 import Button from '../../../ui/buttons/button/button';
 import routesUrl from '../../../utils/routesData';
 import Typography from '../../../ui/typography/typography';
+import { TTemplateBot } from '../../../services/types/bot';
 
-interface IBotTemplate {
-  title: string;
-  description: string;
-  id: string;
+interface ITemplatePopup {
+  template: TTemplateBot;
   onClick?: () => void;
 }
 
@@ -32,46 +31,25 @@ interface IImage {
 }
 
 const image: IImage = {
-  'Бот автоответчик': (
-    <ImageAnswer className={stylesBotTemplate.bot_template_image} />
-  ),
-  'Доставка еды': (
-    <ImageFood className={stylesBotTemplate.bot_template_image} />
-  ),
-  'Демо бот': <ImageDemo className={stylesBotTemplate.bot_template_image} />,
-  Опрос: <ImagePoll className={stylesBotTemplate.bot_template_image} />,
-  'Лидогенерация/HR ререререре...': (
-    <ImageLead className={stylesBotTemplate.bot_template_image} />
-  ),
-  'Онлайн школа/Вебинар': (
-    <ImageLearn className={stylesBotTemplate.bot_template_image} />
-  ),
+  'Бот автоответчик': <ImageAnswer className={styles.bot_template_image} />,
+  'Доставка еды': <ImageFood className={styles.bot_template_image} />,
+  'Демо бот': <ImageDemo className={styles.bot_template_image} />,
+  Опрос: <ImagePoll className={styles.bot_template_image} />,
+  'Лидогенерация/HR': <ImageLead className={styles.bot_template_image} />,
+  'Онлайн школа/Вебинар': <ImageLearn className={styles.bot_template_image} />,
   'Закрытый клуб по под...': (
-    <ImagePrivate className={stylesBotTemplate.bot_template_image} />
+    <ImagePrivate className={styles.bot_template_image} />
   ),
   'Агентство по недвижимости': (
-    <ImageReal className={stylesBotTemplate.bot_template_image} />
+    <ImageReal className={styles.bot_template_image} />
   ),
-  Развлечения: (
-    <ImageEntertain className={stylesBotTemplate.bot_template_image} />
-  ),
-  'Салон красоты': (
-    <ImageBeauty className={stylesBotTemplate.bot_template_image} />
-  ),
-  'Онлайн-покупки': (
-    <ImageCom className={stylesBotTemplate.bot_template_image} />
-  ),
-  'Вопрос/ответ': (
-    <ImageQuest className={stylesBotTemplate.bot_template_image} />
-  ),
+  Развлечения: <ImageEntertain className={styles.bot_template_image} />,
+  'Салон красоты': <ImageBeauty className={styles.bot_template_image} />,
+  'Онлайн-покупки': <ImageCom className={styles.bot_template_image} />,
+  'Вопрос/ответ': <ImageQuest className={styles.bot_template_image} />,
 };
 
-const BotTemplatePopup: FC<IBotTemplate> = ({
-  title,
-  description,
-  id,
-  onClick,
-}): JSX.Element | null => {
+const BotTemplatePopup: FC<ITemplatePopup> = ({ template, onClick }) => {
   const data = [
     'Что настроено в шаблоне',
     'Что настроено в шаблоне',
@@ -86,27 +64,24 @@ const BotTemplatePopup: FC<IBotTemplate> = ({
   };
 
   return (
-    <div className={stylesBotTemplate.bot_template}>
+    <div className={styles.bot_template}>
       <div>
-        {image[title]}
-        <div className={stylesBotTemplate.bot_template_description}>
+        {image[template.title]}
+        <div className={styles.bot_template_description}>
           <Typography
             tag="h2"
             fontFamily="secondary"
-            className={stylesBotTemplate.bot_template_title}
+            className={styles.bot_template_title}
           >
-            {title}
+            {template.title}
           </Typography>
-          <Typography tag="p">{description}</Typography>
-          <ul className={stylesBotTemplate.bot_template_list}>
+          <Typography tag="p">{template.description}</Typography>
+          <ul className={styles.bot_template_list}>
             {data.map((item, index) => (
-              <li
-                key={item + +index}
-                className={stylesBotTemplate.bot_template_item}
-              >
+              <li key={item + +index} className={styles.bot_template_item}>
                 <Typography
                   tag="span"
-                  className={stylesBotTemplate.bot_template_item_index}
+                  className={styles.bot_template_item_index}
                 >
                   {index + 1}
                   {'>'}
@@ -118,18 +93,19 @@ const BotTemplatePopup: FC<IBotTemplate> = ({
         </div>
       </div>
 
-      <div className={stylesBotTemplate.bot_template_buttons}>
+      <div className={styles.bot_template_buttons}>
         <button
-          className={stylesBotTemplate.bot_template_cancel}
+          className={styles.bot_template_cancel}
           onClick={onClick}
           type="button"
         >
           Отмена
         </button>
 
-        <div className={stylesBotTemplate.bot_template_add_button}>
+        <div className={styles.bot_template_add_button}>
           <Button
-            onClick={() => addBot(id, title)}
+            // eslint-disable-next-line no-underscore-dangle
+            onClick={() => addBot(template._id, template.title)}
             size="large"
             variant="default"
             color="green"

--- a/src/components/popups/bot-template-popup/bot-template-popup.tsx
+++ b/src/components/popups/bot-template-popup/bot-template-popup.tsx
@@ -79,9 +79,10 @@ const BotTemplatePopup: FC<IBotTemplate> = ({
     'Что настроено в шаблоне',
   ];
   const history = useNavigate();
-  const addBot = (templateId: string) => {
-    // добавить подключение к редаксу
-    history(`/${routesUrl.addBot}?template=${templateId}`);
+  const addBot = (templateId: string, templateTitle: string) => {
+    history(
+      `/${routesUrl.addBot}?template=${templateId}&title=${templateTitle}`
+    );
   };
 
   return (
@@ -128,7 +129,7 @@ const BotTemplatePopup: FC<IBotTemplate> = ({
 
         <div className={stylesBotTemplate.bot_template_add_button}>
           <Button
-            onClick={() => addBot(id)}
+            onClick={() => addBot(id, title)}
             size="large"
             variant="default"
             color="green"

--- a/src/components/popups/bot-template-popup/bot-template-popup.tsx
+++ b/src/components/popups/bot-template-popup/bot-template-popup.tsx
@@ -23,6 +23,7 @@ import Typography from '../../../ui/typography/typography';
 interface IBotTemplate {
   title: string;
   description: string;
+  id: string;
   onClick?: () => void;
 }
 
@@ -68,6 +69,7 @@ const image: IImage = {
 const BotTemplatePopup: FC<IBotTemplate> = ({
   title,
   description,
+  id,
   onClick,
 }): JSX.Element | null => {
   const data = [
@@ -77,9 +79,9 @@ const BotTemplatePopup: FC<IBotTemplate> = ({
     'Что настроено в шаблоне',
   ];
   const history = useNavigate();
-  const addBot = () => {
+  const addBot = (templateId: string) => {
     // добавить подключение к редаксу
-    history(routesUrl.addBot);
+    history(`/${routesUrl.addBot}?template=${templateId}`);
   };
 
   return (
@@ -126,7 +128,7 @@ const BotTemplatePopup: FC<IBotTemplate> = ({
 
         <div className={stylesBotTemplate.bot_template_add_button}>
           <Button
-            onClick={addBot}
+            onClick={() => addBot(id)}
             size="large"
             variant="default"
             color="green"

--- a/src/components/popups/more-mybot/more-mybot.module.scss
+++ b/src/components/popups/more-mybot/more-mybot.module.scss
@@ -3,6 +3,12 @@
 
 $switching-width-menu: ($min-content-width + 100px);
 
+.layout {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+}
+
 .container {
   @include position(absolute, 60px, $left: 50%);
   width: 244px;

--- a/src/components/popups/more-mybot/more-mybot.tsx
+++ b/src/components/popups/more-mybot/more-mybot.tsx
@@ -21,6 +21,9 @@ import routesUrl from '../../../utils/routesData';
 import SwitchBotMenuPopup from './switch-bot-menu-popup';
 import useModal from '../../../services/hooks/use-modal';
 import Typography from '../../../ui/typography/typography';
+import ModalOverlayPopup from '../modal-overlay-popup/modal-overlay-popup';
+import { deleteBotAction } from '../../../services/actions/bots/deleteBot';
+import { useAppDispatch } from '../../../services/hooks/hooks';
 
 interface IMoreMybotPopup {
   setIsOpen: Dispatch<SetStateAction<boolean>>;
@@ -30,7 +33,8 @@ interface IMoreMybotPopup {
 const MoreMybotPopup: FC<IMoreMybotPopup> = ({
   setIsOpen,
   idMyBot = '2222222',
-}): JSX.Element => {
+}) => {
+  const dispatch = useAppDispatch();
   const matches = useMediaQuery('(max-width: 420px)');
   // м.б. отдавать наружу выбор пункта? хз хз..
   const [itemSelected, setItemSelected] = useState<POPUP_ITEM>(
@@ -45,21 +49,21 @@ const MoreMybotPopup: FC<IMoreMybotPopup> = ({
 
   const navigate = useNavigate();
   const copyBot = () => {
-    // eslint-disable-next-line no-console
-    console.log(`Перепиши id cebe на листочек ${idMyBot}`);
     navigate(routesUrl.addBot);
     setIsOpen(false); // выпадающее меню закрыли
   };
   const deleteBot = () => {
-    // eslint-disable-next-line no-console
-    console.log(
-      `Бот ${idMyBot} будет мстить! Удалять мы его конечно же не будем.. ахахаха`
-    );
+    dispatch(deleteBotAction(idMyBot));
     setIsOpen(false); // выпадающее меню закрыли
   };
 
   return (
     <>
+      <ModalOverlayPopup
+        onClick={() => {
+          console.log('click');
+        }}
+      />
       <div className={styles.container}>
         <ul className={styles.list}>
           <li onClick={copyBot} className={styles.item}>

--- a/src/pages/add-bot-page/add-bot-page.tsx
+++ b/src/pages/add-bot-page/add-bot-page.tsx
@@ -8,6 +8,9 @@ import AddBot from '../../components/add-bot/add-bot/add-bot';
 import { IBot } from '../../utils/types';
 
 const AddBotPage: FC = (): JSX.Element => {
+  const currentUrl = new URL(window.location.href);
+  const template = currentUrl.searchParams.get('template');
+
   const [bot, setBot] = useState<IBot>({
     name: '',
     pages: false,
@@ -26,7 +29,12 @@ const AddBotPage: FC = (): JSX.Element => {
     <div className={stylesAddBotPage.add_bot_page}>
       <AddBot bot={bot} onClick={onClick} />
       <div className={stylesAddBotPage.add_bot_page_container}>
-        <CreateBot botName={bot.name} pages={bot.pages} botURI={bot?.botURI} />
+        <CreateBot
+          botName={bot.name}
+          pages={bot.pages}
+          botURI={bot?.botURI}
+          templateId={template}
+        />
         {bot && (
           <div className={stylesAddBotPage.add_bot_page_works}>
             <HowItWorks />

--- a/src/pages/add-bot-page/add-bot-page.tsx
+++ b/src/pages/add-bot-page/add-bot-page.tsx
@@ -9,7 +9,8 @@ import { IBot } from '../../utils/types';
 
 const AddBotPage: FC = (): JSX.Element => {
   const currentUrl = new URL(window.location.href);
-  const template = currentUrl.searchParams.get('template');
+  const templateId = currentUrl.searchParams.get('template');
+  const templateTitle = currentUrl.searchParams.get('title');
 
   const [bot, setBot] = useState<IBot>({
     name: '',
@@ -33,7 +34,8 @@ const AddBotPage: FC = (): JSX.Element => {
           botName={bot.name}
           pages={bot.pages}
           botURI={bot?.botURI}
-          templateId={template}
+          templateId={templateId}
+          templateTitle={templateTitle}
         />
         {bot && (
           <div className={stylesAddBotPage.add_bot_page_works}>

--- a/src/services/actions/bots/addBot.ts
+++ b/src/services/actions/bots/addBot.ts
@@ -26,31 +26,6 @@ export type TAddBotActions =
   | IAddBotSuccessAction
   | IAddBotErrorAction;
 
-// экшн добавления бота - не используется
-// const addBotAction: AppThunk = (botinfo: TBot, token: string | null, templateId: string | null) => {
-//   return (dispatch: AppDispatch) => {
-//     dispatch({
-//       type: ADDBOT_REQUEST,
-//     });
-//     console.log(botinfo);
-//     addBotApi(botinfo, token)
-//       .then((res) => {
-//         console.log(res);
-//         if (res) {
-//           dispatch({
-//             type: ADDBOT_SUCCESS,
-//             bot: res,
-//           });
-//         }
-//       })
-//       .catch((err) => {
-//         // eslint-disable-next-line no-console
-//         console.log(err);
-//         dispatch({
-//           type: ADDBOT_ERROR,
-//         });
-//       });
-//   };
-// };
+// экшн добавления бота - не используется, код в коммите 08ebaab
 
 export { ADDBOT_REQUEST, ADDBOT_SUCCESS, ADDBOT_ERROR };

--- a/src/services/actions/bots/addBot.ts
+++ b/src/services/actions/bots/addBot.ts
@@ -1,7 +1,7 @@
-import { addBotApi } from '../../../api';
+// import { addBotApi } from '../../../api';
 
 // eslint-disable-next-line import/no-cycle
-import { AppDispatch, AppThunk } from '../../types';
+// import { AppDispatch, AppThunk } from '../../types';
 import { TBot } from '../../types/bot';
 
 const ADDBOT_REQUEST = 'ADDBOT_REQUSET';
@@ -26,31 +26,31 @@ export type TAddBotActions =
   | IAddBotSuccessAction
   | IAddBotErrorAction;
 
-// экшн добавления бота
-const addBotAction: AppThunk = (botinfo: TBot, token: string) => {
-  return (dispatch: AppDispatch) => {
-    dispatch({
-      type: ADDBOT_REQUEST,
-    });
-    console.log(botinfo);
-    addBotApi(botinfo, token)
-      .then((res) => {
-        console.log(res);
-        if (res) {
-          dispatch({
-            type: ADDBOT_SUCCESS,
-            bot: res,
-          });
-        }
-      })
-      .catch((err) => {
-        // eslint-disable-next-line no-console
-        console.log(err);
-        dispatch({
-          type: ADDBOT_ERROR,
-        });
-      });
-  };
-};
+// экшн добавления бота - не используется
+// const addBotAction: AppThunk = (botinfo: TBot, token: string | null, templateId: string | null) => {
+//   return (dispatch: AppDispatch) => {
+//     dispatch({
+//       type: ADDBOT_REQUEST,
+//     });
+//     console.log(botinfo);
+//     addBotApi(botinfo, token)
+//       .then((res) => {
+//         console.log(res);
+//         if (res) {
+//           dispatch({
+//             type: ADDBOT_SUCCESS,
+//             bot: res,
+//           });
+//         }
+//       })
+//       .catch((err) => {
+//         // eslint-disable-next-line no-console
+//         console.log(err);
+//         dispatch({
+//           type: ADDBOT_ERROR,
+//         });
+//       });
+//   };
+// };
 
-export { ADDBOT_REQUEST, ADDBOT_SUCCESS, ADDBOT_ERROR, addBotAction };
+export { ADDBOT_REQUEST, ADDBOT_SUCCESS, ADDBOT_ERROR };

--- a/src/services/actions/bots/deleteBot.ts
+++ b/src/services/actions/bots/deleteBot.ts
@@ -1,0 +1,64 @@
+// import { DeleteBotApi } from '../../../api';
+
+// eslint-disable-next-line import/no-cycle
+import { deleteBotApi } from '../../../api/bots';
+// eslint-disable-next-line import/no-cycle
+import { AppDispatch, AppThunk } from '../../types';
+import { IDeleteBotResponse, TBot } from '../../types/bot';
+
+const DELETE_BOT_REQUEST = 'DELETE_BOT_REQUSET';
+const DELETE_BOT_SUCCESS = 'DELETE_BOT_SUCCESS';
+const DELETE_BOT_ERROR = 'DELETE_BOT_ERROR';
+
+export interface IDeleteBotRequestAction {
+  readonly type: typeof DELETE_BOT_REQUEST;
+}
+
+export interface IDeleteBotSuccessAction {
+  readonly type: typeof DELETE_BOT_SUCCESS;
+  id: TBot['_id'];
+}
+
+export interface IDeleteBotErrorAction {
+  readonly type: typeof DELETE_BOT_ERROR;
+}
+
+// экшн получения шаблонов
+const deleteBotAction: AppThunk = (token: string) => {
+  return (dispatch: AppDispatch) => {
+    dispatch({
+      type: DELETE_BOT_REQUEST,
+    });
+    deleteBotApi(token)
+      .then((res: IDeleteBotResponse) => {
+        if (res) {
+          dispatch({
+            type: DELETE_BOT_SUCCESS,
+            // eslint-disable-next-line no-underscore-dangle
+            id: res._id,
+          });
+        }
+      })
+      .catch((err: { message: string }) => {
+        // eslint-disable-next-line no-console
+        console.log(err.message);
+        dispatch({
+          type: DELETE_BOT_ERROR,
+        });
+      });
+  };
+};
+
+export type TDeleteBotActions =
+  | IDeleteBotRequestAction
+  | IDeleteBotSuccessAction
+  | IDeleteBotErrorAction;
+
+// экшн добавления бота - не используется, код в коммите 08ebaab
+
+export {
+  DELETE_BOT_REQUEST,
+  DELETE_BOT_SUCCESS,
+  DELETE_BOT_ERROR,
+  deleteBotAction,
+};

--- a/src/services/actions/bots/getBot.ts
+++ b/src/services/actions/bots/getBot.ts
@@ -34,7 +34,6 @@ const getBotsAction: AppThunk = (token: string) => {
     });
     getBotsApi(token)
       .then((res) => {
-        console.log(res);
         if (res) {
           dispatch({
             type: GETBOTS_SUCCESS,

--- a/src/services/actions/bots/getBot.ts
+++ b/src/services/actions/bots/getBot.ts
@@ -27,12 +27,12 @@ export type TGetBotsActions =
   | IGetBotsErrorAction;
 
 // экшн получения ботов
-const getBotsAction: AppThunk = (token: string) => {
+const getBotsAction: AppThunk = () => {
   return (dispatch: AppDispatch) => {
     dispatch({
       type: GETBOTS_REQUEST,
     });
-    getBotsApi(token)
+    getBotsApi()
       .then((res) => {
         if (res) {
           dispatch({

--- a/src/services/reducers/bots/getBots.ts
+++ b/src/services/reducers/bots/getBots.ts
@@ -6,6 +6,13 @@ import {
   TGetBotsActions,
 } from '../../actions/bots/getBot';
 
+import {
+  DELETE_BOT_REQUEST,
+  DELETE_BOT_SUCCESS,
+  DELETE_BOT_ERROR,
+  TDeleteBotActions,
+} from '../../actions/bots/deleteBot';
+
 import { TBot } from '../../types/bot';
 
 export type TGetBotsState = {
@@ -16,6 +23,10 @@ export type TGetBotsState = {
   getBotsRequest: boolean;
   getBotsSuccess: boolean;
   getBotsError: boolean;
+
+  deleteBotRequest: boolean;
+  deleteBotSuccess: boolean;
+  deleteBotError: boolean;
 };
 
 const getBotsInitialState: TGetBotsState = {
@@ -26,12 +37,16 @@ const getBotsInitialState: TGetBotsState = {
   getBotsRequest: false,
   getBotsSuccess: false,
   getBotsError: false,
+
+  deleteBotRequest: false,
+  deleteBotSuccess: false,
+  deleteBotError: false,
 };
 
 function getBotsReducer(
   // eslint-disable-next-line @typescript-eslint/default-param-last
   state = getBotsInitialState,
-  action: TGetBotsActions
+  action: TGetBotsActions | TDeleteBotActions
 ) {
   switch (action.type) {
     // экшены получения ботов
@@ -55,6 +70,27 @@ function getBotsReducer(
         ...state,
         getBotsRequest: false,
         getBotsError: true,
+      };
+    }
+    case DELETE_BOT_REQUEST: {
+      return {
+        ...state,
+        deleteBotRequest: true,
+        deleteBotError: false,
+      };
+    }
+    case DELETE_BOT_SUCCESS: {
+      return {
+        ...state,
+        // eslint-disable-next-line no-underscore-dangle
+        bots: [...state.bots].filter((bot) => bot._id !== action.id),
+      };
+    }
+    case DELETE_BOT_ERROR: {
+      return {
+        ...state,
+        deleteBotRequest: false,
+        deleteBotError: true,
       };
     }
     default: {

--- a/src/services/types/bot.ts
+++ b/src/services/types/bot.ts
@@ -1,3 +1,15 @@
+export type TMessenger = {
+  name: string;
+  pages: Array<string>;
+  accessKey: string;
+  url: string;
+};
+
+export type TCreateBot = {
+  title: string;
+  messengers?: Array<TMessenger>;
+};
+
 // Типизация данных бота
 export type TBot = {
   type: string;
@@ -6,12 +18,7 @@ export type TBot = {
   description: string;
   features: Array<Object>;
   profile: string;
-  messengers: Array<{
-    name: string;
-    page: string;
-    accessKey: string;
-    url: string;
-  }>;
+  messengers: Array<TMessenger>;
   commands: Array<string>;
   content: Array<Object>;
   isToPublish: boolean;

--- a/src/services/types/bot.ts
+++ b/src/services/types/bot.ts
@@ -40,6 +40,7 @@ export type TTemplateBot = {
 };
 
 export interface IAddBotResponse extends TBot {}
+export interface IDeleteBotResponse extends TBot {}
 
 export interface IGetBotsResponse extends Array<TBot> {}
 

--- a/src/services/types/index.ts
+++ b/src/services/types/index.ts
@@ -30,6 +30,7 @@ import { TGetPlatformsState } from '../reducers/platforms/getPlatforms';
 import { TGetPlatformsActions } from '../actions/platforms/getPlatforms';
 
 import store from '../store';
+import { TDeleteBotActions } from '../actions/bots/deleteBot';
 
 export type TStore = {
   signup: TSignupState;
@@ -54,7 +55,8 @@ export type TApplicationActions =
   | TGetBotsActions
   | TAddBotActions
   | TGetTemplatesBotsActions
-  | TGetPlatformsActions;
+  | TGetPlatformsActions
+  | TDeleteBotActions;
 
 export type AppThunk<TReturn = void> = ActionCreator<
   ThunkAction<TReturn, Action, RootState, TApplicationActions>


### PR DESCRIPTION
Добавление бота с шаблоном и без. 
Минимизирована работа со стором (из него только получаем шаблон).

- когда на главной странице пользователь выбирает шаблон и нажимает "Добавить бота", происходит перенаправление на страницу `/add-bot?template={templateId}&title={templateTitle}`
- если на странице по id находится бот в сторе шаблонов, после выбора мессенджера выводится `"Бот будет создан на основе {templateTitle}"`
- если пользователь создаёт бота не на основе шаблона - надписи нет
- далее отправляется запрос на сохранение бота
- при успешном сохранении - переход на страницу билдера по адресу `http://localhost:3000/bot-builder?id={botId}&type=custom`

TODO?
- в `components/dashbord/bot-templates` вероятно можно убрать dispatch и оставить просто получение шаблонов, не записывая в стор
- проверить, что в билдере заполена информация, соответствующая шаблону